### PR TITLE
Fx injected syntax

### DIFF
--- a/src/server/config/utils.js
+++ b/src/server/config/utils.js
@@ -41,6 +41,6 @@ export function loadEnv(options = {}) {
     });
 
   return {
-    'process.env': JSON.stringify(env),
+    'process.env': `(${JSON.stringify(env)})`,
   };
 }


### PR DESCRIPTION
`{"foo": "baa"}.foo` -> `({"foo": "baa"}).foo`

Storybook injects the some environment variables as a object literal. Previously invalid syntax was being fixed by babel.

