### PR TITLE
`runnign` -> `running`

### DIFF
--- a/dist/server/babel_config.js
+++ b/dist/server/babel_config.js
@@ -78,7 +78,7 @@ function loadFromPath(babelConfigPath) {
   // Remove react-hmre preset.
   // It causes issues with react-storybook.
   // We don't really need it.
-  // Earlier, we fix this by runnign storybook in the production mode.
+  // Earlier, we fix this by running storybook in the production mode.
   // But, that hide some useful debug messages.
   if (config.presets) {
     removeReactHmre(config.presets);

--- a/src/server/babel_config.js
+++ b/src/server/babel_config.js
@@ -34,7 +34,7 @@ function loadFromPath(babelConfigPath) {
   // Remove react-hmre preset.
   // It causes issues with react-storybook.
   // We don't really need it.
-  // Earlier, we fix this by runnign storybook in the production mode.
+  // Earlier, we fix this by running storybook in the production mode.
   // But, that hide some useful debug messages.
   if (config.presets) {
     removeReactHmre(config.presets);


### PR DESCRIPTION
This typo **is not caused by changes in this fork**, but people can found it by:

![image](https://cloud.githubusercontent.com/assets/10692276/25070683/ed95b430-22d7-11e7-8f89-f2caac3ece6b.png)

![image](https://cloud.githubusercontent.com/assets/10692276/25070685/02009d4a-22d8-11e7-86bf-3c15fbf2cc35.png)
